### PR TITLE
goddamn vets

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -106,5 +106,6 @@ def register_pt (data:  map[str, str]):
     appt.patient = patient
 
     with app.app_context():
-        db.session.add_all([client, vet, patient, appt])
+        db.session.add_all([client, patient, appt])
+        db.session.merge(vet)
         db.session.commit()


### PR DESCRIPTION
so vets are a problem. Namely leaving it empty creates an empty entry and then all future entries will fail a unique check on the name of the vet. Just removing the vet will break the DB because it will error on a relationship that isn't properly defined. Using an upsert to fix it now (so it will update a blank vet entry to a blank vet entry) until I can figure out a proper way to do this. It is seeming increaseingly like I will just need to hop down a level to handwriting statements, which allows for an insert or ignore behavior that's exactly what I want.